### PR TITLE
Use gke-gcloud-auth-plugin in composer-vars-update

### DIFF
--- a/.github/workflows/composer-vars-update.yml
+++ b/.github/workflows/composer-vars-update.yml
@@ -52,6 +52,7 @@ jobs:
               uses: google-github-actions/setup-gcloud@v1
               with:
                 version: '412.0.0'
+                install_components: gke-gcloud-auth-plugin
             - name: Composer Storage Data Import
               id: composer_storage_data_import
               run: |
@@ -62,6 +63,8 @@ jobs:
                 --project=${{ inputs.GCP_PROJECT }}
             - name: Composer Variables Import
               id: composer_variables_import
+              env:
+                USE_GKE_GCLOUD_AUTH_PLUGIN: True
               run: |
                 gcloud composer environments run \
                 ${{ inputs.COMPOSER_ENVIRONMENT_NAME }} \

--- a/.github/workflows/composer-vars-update.yml
+++ b/.github/workflows/composer-vars-update.yml
@@ -37,10 +37,11 @@ jobs:
             id-token: write
 
         steps:
-            - uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v3
             - name: Authenticate to Google Cloud
               id: gcloud_auth
-              uses: 'google-github-actions/auth@v0'
+              uses: google-github-actions/auth@v1
               with:
                   workload_identity_provider: ${{ secrets.WORKLOAD_ID_PROVIDER }}
                   service_account: ${{ secrets.SERVICE_ACCOUNT }}
@@ -48,12 +49,9 @@ jobs:
                   token_format: 'access_token'
             - name: Set up Cloud SDK
               id: setup_cloud_sdk
-              uses: google-github-actions/setup-gcloud@v0
+              uses: google-github-actions/setup-gcloud@v1
               with:
-                # REVIEW: 410.0.0 has a bug that breaks composer commands that
-                # run `kubectl exec`, so pin until fixed.
-                # See https://issuetracker.google.com/issues/259429199.
-                version: '409.0.0'
+                version: '412.0.0'
             - name: Composer Storage Data Import
               id: composer_storage_data_import
               run: |


### PR DESCRIPTION
Required since kubectl v1.26. Issue with gcloud 410 has also been fixed