### PR TITLE
Add parameter DOCKER_FILE to build-publish-image-gcr.yml

### DIFF
--- a/.github/workflows/build-publish-image-gcr.yml
+++ b/.github/workflows/build-publish-image-gcr.yml
@@ -21,6 +21,9 @@ on:
             DOCKER_PATH_CONTEXT:
                 required: true
                 type: string
+            DOCKER_FILE:
+                required: false
+                type: string
         outputs:
             version_number:
                 value: ${{ jobs.build.outputs.version_number }}
@@ -78,6 +81,7 @@ jobs:
               uses: docker/build-push-action@v3
               with:
                   context: ${{ inputs.DOCKER_PATH_CONTEXT }}
+                  file: ${{ inputs.DOCKER_FILE }}
                   push: true
                   tags: ${{ steps.docker_meta.outputs.tags }}
                   cache-from: type=gha


### PR DESCRIPTION
## What?

Add parameter DOCKER_FILE to build-publish-image-gcr.yml

By default `{context}/Dockerfile` is used https://github.com/docker/build-push-action

## Why?

Need it for https://github.com/nansen-ai/evmchain-etl/pull/350